### PR TITLE
Rework build system and python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ arch
 ./src/build
 
 __pycache__
+
+build
+cmake-build-*
+uv.lock
+
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 4.0.2)
+
+set(SKBUILD_PROJECT_VERSION "0.1.0" CACHE STRING "Project version")
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES native)
+endif()
+
+project(CIANNA VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES C)
+
+# Select backends to enables
+option(CIANNA_USE_BLAS "Enable OpenBLAS support" ON)
+option(CIANNA_USE_CUDA "Enable CUDA support" ON)
+option(CIANNA_CUDA_AUTO_GEN "Enable `nv_bfloat16`  / `__half` if supported" ON)
+
+# Select features to enables
+option(CIANNA_USE_OPENMP "Enable OpenMP library" ON)
+option(CIANNA_USE_LPTHREAD "Link with pthread library" ON)
+
+option(CIANNA_PYTHON_INTERFACE "Enable python interface" OFF)
+
+# COMPILER DEFINES STRUCTURES
+add_compile_definitions(
+        MAX_LAYERS_NB=200
+        MAX_NETWORKS_NB=10
+        CUDA_THREADS_PER_BLOCKS=256
+)
+
+include(CheckPIESupported)
+check_pie_supported(LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wno-unused-result -Wno-uninitialized -fmax-errors=2 -Wno-unknown-pragmas")
+set(INTERPROCEDURAL_OPTIMIZATION TRUE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Backends
+## BLAS
+if (CIANNA_USE_BLAS)
+    find_package(BLAS COMPONENTS C REQUIRED)
+    add_compile_definitions(BLAS)
+endif ()
+
+## CUDA
+if (CIANNA_USE_CUDA)
+    enable_language(CUDA)
+    check_pie_supported(LANGUAGES CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    add_compile_definitions(CUDA)
+    include(cmake/cuda.cmake)
+    # TODO: add -arch=sm_89 -D GEN_AMPERE
+endif ()
+
+
+# Math library
+find_library(MATH_LIBRARY m)
+# OpenMP
+if (CIANNA_USE_OPENMP)
+    find_package(OpenMP COMPONENTS C REQUIRED)
+    add_compile_definitions(OPEN_MP)
+    set(OPENMP_LIBS OpenMP::OpenMP_C)
+endif ()
+# lpthread
+if (CIANNA_USE_LPTHREAD)
+    set(PTHREAD_LIBS pthread)
+endif ()
+
+add_subdirectory(src)
+
+# install targets
+if (SKBUILD OR CIANNA_PYTHON_INTERFACE)
+    install(TARGETS CIANNA DESTINATION .)
+endif ()

--- a/cmake-doc.md
+++ b/cmake-doc.md
@@ -1,0 +1,76 @@
+# CMake
+
+Cmake is an out-of-source build system.
+You can create a build directory as such:
+
+```shell
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -B build
+```
+
+```shell
+cmake --build build
+```
+
+## Options
+
+This is a list of options that can be enabled or disabled to compile only specific features of CIANNA.
+_They should be passed to CMake using the `-D` option._
+
+| Variable             | Description                                   | Values     |
+|----------------------|-----------------------------------------------|------------|
+| CIANNA_USE_CUDA      | Enable CUDA support                           | `ON`/`OFF` |
+| CIANNA_USE_BLAS      | Enable OpenBLAS support                       | `ON`/`OFF` |
+| CIANNA_USE_OPENMP    | Enable OpenMP library                         | `ON`/`OFF` |
+| CIANNA_USE_LPTHREAD  | Link with pthread library                     | `ON`/`OFF` |
+| CIANNA_CUDA_AUTO_GEN | Enable `nv_bfloat16`  / `__half` if supported | `ON`/`OFF` |
+| GEN_AMPERE           | Assume cuda support `__half`                  |            |
+| GEN_VOLTA            | Assume cuda support `nv_bfloat16`             |            |
+
+> Note: `GEN_AMPERE` and `GEN_VOLTA` should be passed without values, just `GEN_AMPERE` or `GEN_VOLTA`.
+
+## Variables
+
+This is a list of variables that can be used to modify the behavior of the build.
+_They should be passed to CMake using the `-D` option._
+
+| Variable                                                                                                         | Recommended | Alternative                   | Description                                        |
+|------------------------------------------------------------------------------------------------------------------|-------------|-------------------------------|----------------------------------------------------|
+| [CMAKE_BUILD_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE) | `Release`   | `Debug`, `RelWithDebInfo`     |                                                    |
+| [CUDAToolkit_ROOT](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html#search-behavior)              |             | -DCUDAToolkit_ROOT=/some/path |                                                    |
+| [CMAKE_CUDA_ARCHITECTURES](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html)                 | `native`    | `89`                          | Allow to select the cuda architecture to use       |
+| BLAS_DIR                                                                                                         |             |                               | Allow to specify a path to the blas implementation |
+| BLA_VENDOR                                                                                                       |             | `OPENBLAS`                    | Allow to set the vendor to use                     |
+
+> Example
+> ```shell
+> cmake -DCMAKE_BUILD_TYPE=Release -DBLA_VENDOR=OPENBLAS -DCMAKE_CUDA_ARCHITECTURES='native' -B build
+> cmake --build build
+> ```
+
+## Check compile commands
+
+Cmake is set to output a [compile_commands.json](build/compile_commands.json) file with the command used to compile the
+code.
+
+## Cuda stuff
+
+By setting `CMAKE_CUDA_ARCHITECTURES` to `native` the build system will automatically detect the architecture of the
+GPU.
+
+Using `CheckSourceRuns`, `__half` and `nv_bfloat16` support can be checked by CMake easily.
+`cmake/cuda.cmake` implement the necessary code to define, if supported, `GEN_AMPERE` and `GEN_VOLTA`.
+
+> Note: May not work if targeting older gpu than the one used to compile the code.
+
+```cmake
+include(CheckSourceRuns)
+
+check_source_runs(CUDA
+        "
+#include <cuda_fp16.h>
+__global__ void f(__half x) {}
+int main() { return 0; }
+"
+        GEN_VOLTA)
+```
+

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -1,0 +1,20 @@
+include(CheckSourceRuns)
+# The following tests should ensure that the features are enabled only when supported.
+
+if (CIANNA_CUDA_AUTO_GEN)
+    check_source_runs(CUDA
+            "
+#include <cuda_fp16.h>
+__global__ void f(__half x) {}
+int main() { return 0; }
+"
+            GEN_VOLTA)
+
+    check_source_runs(CUDA
+            "
+#include <cuda_bf16.h>
+__global__ void f(nv_bfloat16 x) {}
+int main() { return 0; }
+"
+            GEN_AMPERE)
+endif ()

--- a/compile.cp
+++ b/compile.cp
@@ -43,7 +43,7 @@ for i in $*
 do
 	if [ $i  = "CUDA" ]
 	then
-		cuda_arg="$cuda_arg -D CUDA -D comp_CUDA -lcublas -lcudart -arch=sm_89 -D GEN_AMPERE"
+		cuda_arg="$cuda_arg -D CUDA -D __CUDACC__ -lcublas -lcudart -arch=sm_89 -D GEN_AMPERE"
 		arg="$arg -D CUDA -lcublas -lcudart -lcurand -L $cuda_lib_path"
 		cuda_src="cuda_main.cu cuda_conv_layer.cu cuda_dense_layer.cu cuda_pool_layer.cu cuda_norm_layer.cu cuda_lrn_layer.cu cuda_activ_functions.cu"
 		cuda_obj="cuda/cuda_main.o cuda/cuda_conv_layer.o cuda/cuda_dense_layer.o cuda/cuda_pool_layer.o cuda/cuda_lrn_layer.o cuda/cuda_norm_layer.o cuda/cuda_activ_functions.o"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [ "hatchling", "numpy>=1.26", "scikit-build-core~=0.11.6", "uv-dynamic-versioning" ]
+
+[project]
+name = "cianna"
+description = "CIANNA is a general-purpose deep learning framework primarily developed and used for astronomical data analysis."
+readme = "README.md"
+requires-python = ">=3.9,<3.14"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+dynamic = [ "version" ]
+
+dependencies = [
+  "numpy>=1.26",
+]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.build.targets.wheel.hooks.scikit-build]
+experimental = true
+
+[tool.scikit-build]
+cmake.version = ">=4.0"
+ninja.version = ">=1.11"
+
+[tool.scikit-build.cmake.define]
+CIANNA_USE_CUDA = { env = "CIANNA_USE_CUDA" }
+CIANNA_CUDA_AUTO_GEN = { env = "CIANNA_CUDA_AUTO_GEN" }
+CMAKE_CUDA_ARCHITECTURES = { env = "CMAKE_CUDA_ARCHITECTURES" }
+
+CIANNA_USE_BLAS = { env = "CIANNA_USE_BLAS" }
+CIANNA_USE_OPENMP = { env = "CIANNA_USE_OPENMP" }
+CIANNA_USE_LPTHREAD = { env = "CIANNA_USE_LPTHREAD" }
+CIANNA_PYTHON_INTERFACE = { env = "CIANNA_PYTHON_INTERFACE" }
+
+[tool.uv]
+#package = false
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+pattern = "default-unprefixed"
+fallback_version = "0.0.0"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Backends
+add_subdirectory(naiv)
+
+if (CIANNA_USE_BLAS)
+    add_subdirectory(blas)
+endif ()
+
+if (CIANNA_USE_CUDA)
+    add_subdirectory(cuda)
+endif ()
+
+# common
+include(common.cmake)
+
+# Python interface
+if (SKBUILD OR CIANNA_PYTHON_INTERFACE)
+    include(python.cmake)
+endif ()
+
+# main
+include(main.cmake)

--- a/src/blas/CMakeLists.txt
+++ b/src/blas/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB BACKEND_BLAS_SRC *.c)
+add_library(backend_blas ${BACKEND_BLAS_SRC})
+
+target_link_libraries(backend_blas PRIVATE BLAS::BLAS ${PTHREAD_LIBS} ${OPENMP_LIBS} ${MATH_LIBRARY})
+set_target_properties(backend_blas PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_library(cianna::backend::blas ALIAS backend_blas)

--- a/src/common.cmake
+++ b/src/common.cmake
@@ -1,0 +1,25 @@
+add_library(common
+        activ_functions.c
+        auxil.c
+        conv_layer.c
+        dense_layer.c
+        initializers.c
+        lrn_layer.c
+        norm_layer.c
+        pool_layer.c
+        vars.c)
+
+target_link_libraries(common PUBLIC ${PTHREAD_LIBS} ${OPENMP_LIBS} ${MATH_LIBRARY})
+set_target_properties(common PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_library(cianna::common ALIAS common)
+
+target_link_libraries(common PUBLIC cianna::backend::naive)
+
+if (CIANNA_USE_BLAS)
+    target_link_libraries(common PUBLIC cianna::backend::blas)
+endif ()
+
+if (CIANNA_USE_CUDA)
+    target_link_libraries(common PUBLIC cianna::backend::cuda)
+endif ()

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB BACKEND_CUDA_SRC *.cu)
+add_library(backend_cuda ${BACKEND_CUDA_SRC})
+
+target_link_libraries(backend_cuda PRIVATE CUDA::curand CUDA::cudart CUDA::cublas)
+set_target_properties(backend_cuda PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_library(cianna::backend::cuda ALIAS backend_cuda)

--- a/src/defs.h
+++ b/src/defs.h
@@ -34,7 +34,7 @@
 #include <unistd.h>
 #include <locale.h>
 
-#ifdef comp_CUDA
+#ifdef __CUDACC__
 #ifdef CUDA
 #include <cuda_runtime.h>
 #include <cublas_v2.h>

--- a/src/main.cmake
+++ b/src/main.cmake
@@ -1,0 +1,2 @@
+add_executable(main main.c)
+target_link_libraries(main PRIVATE cianna::common)

--- a/src/naiv/CMakeLists.txt
+++ b/src/naiv/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB BACKEND_NAIVE_SRC *.c)
+add_library(backend_naive ${BACKEND_NAIVE_SRC})
+
+target_link_libraries(backend_naive PRIVATE ${PTHREAD_LIBS} ${OPENMP_LIBS} ${MATH_LIBRARY})
+set_target_properties(backend_naive PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_library(cianna::backend::naive ALIAS backend_naive)

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -137,7 +137,6 @@ void rand_uniform(  void *tab, int dim_in, int dim_out, int bias_padding, float 
 #ifdef BLAS
 void blas_dense_define(layer *current);
 void blas_conv_define(layer *current);
-
 #endif 
 
 void pool_define(layer *current);
@@ -186,7 +185,7 @@ void im2col_fct
 //       CUDA public prototypes
 //######################################
 
-#ifdef comp_CUDA
+#ifdef __CUDACC__
 //when compiled by nvcc must be exported as regular C prototypes
 //when compiled by gcc act as regular prototype C natively
 extern "C"
@@ -296,7 +295,7 @@ size_t cuda_convert_lrn_layer(layer *current);
 	
 //######################################
 
-#ifdef comp_CUDA
+#ifdef __CUDACC__
 }
 #endif
 

--- a/src/python.cmake
+++ b/src/python.cmake
@@ -1,0 +1,15 @@
+#set(Python_FIND_VIRTUALENV FIRST)
+find_package(Python 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+
+# NumPy headers
+execute_process(
+        COMMAND "${Python_EXECUTABLE}"
+        -c "import numpy; print(numpy.get_include())"
+        OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+Python_add_library(CIANNA MODULE WITH_SOABI python_module.c)
+
+target_link_libraries(CIANNA PRIVATE cianna::common Python::NumPy)
+target_link_options(CIANNA PRIVATE --disable-gil)


### PR DESCRIPTION
Hello

This PR aims to make it possible to install `CIANNA` as a Python package.

_The following was done to support the usage of `CIANNA` at the Laboratoire d'Astrophysique de Bordeaux, by Alexandre Mechineau with N Kessler._

## Dev

To do that, I replaced the `compile.cp` with a proper `CMake` configuration.
From it, I was able to leverage `uv`, `scikit-build-core` and `hatchling` to produce a python package that can be installed from its source.
Pre-compiled version may be possible, but I'm not a specialist.

At the moment, the only minor issue is due to the fact that `hatch` cannot use `scikit-build-core` in editable mode.
This could be fixed by removing the use of `uv-dynamic-versioning`, which would allow bypassing `hatch`.
The feature is marked as experimental.

TLDR: `uv sync` does not work in this repository. To test the process, I needed to make a test project and perform the install with `uv add  ../cianna`.

## User
From the user's point of view, the following `pyproject.toml` allows `uv` to install cianna in a proper venv, while still keeping the ability to configure backends' availability.

```toml
[project]
name = "cianna-demo"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.9"
dependencies = [
    "cianna",
]

[tool.uv.sources]
cianna = { path = "../CIANNA" }
[tool.uv]
extra-build-variables = { cianna = { CIANNA_USE_CUDA = 'ON', CIANNA_USE_BLAS = 'ON', CIANNA_USE_OPENMP = 'ON', CIANNA_USE_LPTHREAD = 'ON' } }
```